### PR TITLE
Fix timezones

### DIFF
--- a/app/Args.hs
+++ b/app/Args.hs
@@ -2,7 +2,7 @@ module Args (Args (..), getArgs) where
 
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
-import Entities (Person (..), Minutes (..), Days (..))
+import Entities (Days (..), Minutes (..), Person (..))
 import Options.Applicative
 import Text.Read (readMaybe)
 
@@ -13,7 +13,8 @@ data Args = Args
     argsStartDate :: Maybe Day,
     argsTimespan :: Days,
     argsInPerson :: Int,
-    argsFeelingLucky :: Bool
+    argsFeelingLucky :: Bool,
+    argsShowLocalTime :: Bool
   }
   deriving (Eq, Show)
 
@@ -66,6 +67,10 @@ parseArgs =
       ( long "lucky"
           <> short 'l'
           <> help "Make the app suggest a single best meeting time (and room if needed)."
+      )
+    <*> switch
+      ( long "local"
+          <> help "Display meeting times in your local timezone. By default, times are shown in London time."
       )
 
 readDate :: ReadM Day

--- a/meet.cabal
+++ b/meet.cabal
@@ -27,6 +27,7 @@ library
     build-depends:
         base ^>=4.17 || ^>=4.18 || ^>=4.19,
         time,
+        tz,
         req,
         text,
         aeson,

--- a/rooms/Args.hs
+++ b/rooms/Args.hs
@@ -8,7 +8,8 @@ import Text.Read (readMaybe)
 data Args = Args
   { argsStartDate :: Maybe Day,
     argsTimespan :: Days,
-    argsCapacity :: Int
+    argsCapacity :: Int,
+    argsShowLocalTime :: Bool
   }
   deriving (Eq, Show)
 
@@ -39,6 +40,10 @@ parseArgs =
           <> metavar "PEOPLE"
           <> help "Minimum capacity needed for the meeting room. Defaults to 0."
           <> value 0
+      )
+    <*> switch
+      ( long "local"
+          <> help "Display meeting times in your local timezone. By default, times are shown in London time."
       )
 
 readDate :: ReadM Day

--- a/rooms/Main.hs
+++ b/rooms/Main.hs
@@ -8,7 +8,7 @@ import Control.Monad (when)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Time.Calendar (addDays)
-import Data.Time.LocalTime (LocalTime (..), TimeOfDay (..), getCurrentTimeZone, localTimeToUTC)
+import Data.Time.LocalTime (LocalTime (..), TimeOfDay (..), getCurrentTimeZone, localTimeToUTC, timeZoneOffsetString)
 import Entities (Days (..), Minutes (..), Room (..), allRooms, schedule)
 import Meetings (getRoomMeetings)
 import Print (prettyPrint)

--- a/rooms/Main.hs
+++ b/rooms/Main.hs
@@ -5,10 +5,11 @@ module Main where
 import Args (Args (..), getArgs)
 import Azure (fetchSchedules, getToken)
 import Control.Monad (when)
+import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Time.Calendar (addDays)
 import Data.Time.LocalTime (LocalTime (..), TimeOfDay (..), getCurrentTimeZone, localTimeToUTC)
-import Entities (Days (..), Minutes (..), Room (..), schedule, allRooms)
+import Entities (Days (..), Minutes (..), Room (..), allRooms, schedule)
 import Meetings (getRoomMeetings)
 import Print (prettyPrint)
 import System.Exit (exitSuccess)
@@ -20,15 +21,18 @@ main = do
   let searchStartDate = argsStartDate args
       searchSpanDays = argsTimespan args
       minCapacity = argsCapacity args
+      showInLocalTime = argsShowLocalTime args
 
+  -- Default start date is today but in London
   startDate' <- case searchStartDate of
     Just d -> pure d
-    Nothing -> localDay <$> getCurrentLocalTime
+    Nothing -> localDay <$> getCurrentLondonTime
 
-  localTz <- getCurrentTimeZone
-  let startTime' = localTimeToUTC localTz $ LocalTime startDate' (TimeOfDay 8 30 0)
+  -- Only count meetings between 8:30 and 17:30 in London
+  londonTz <- getCurrentLondonTZ
+  let startTime' = localTimeToUTC londonTz $ LocalTime startDate' (TimeOfDay 8 30 0)
   let endDate' = addDays (fromIntegral $ unDays searchSpanDays - 1) startDate'
-      endTime' = localTimeToUTC localTz $ LocalTime endDate' (TimeOfDay 17 30 0)
+      endTime' = localTimeToUTC londonTz $ LocalTime endDate' (TimeOfDay 17 30 0)
 
   let okRooms = filter ((>= minCapacity) . capacity) allRooms
   when (null okRooms) $ do
@@ -41,8 +45,14 @@ main = do
   let totalChunks = case roomSchs of
         [] -> 0
         s : _ -> length (schedule s)
-  let goodMeetings = getRoomMeetings roomSchs minCapacity totalChunks startTime' (Minutes 30) localTz
+  let goodMeetings = getRoomMeetings roomSchs minCapacity totalChunks startTime' (Minutes 30) londonTz
+
+  -- Display times in London unless otherwise specified
+  displayTz <- if showInLocalTime then getCurrentTimeZone else pure londonTz
+  let displayTzText = T.pack $ "UTC" <> timeZoneOffsetString displayTz
 
   case goodMeetings of
     [] -> T.putStrLn "No meetings were available. :("
-    _ -> prettyPrint goodMeetings
+    _ -> do
+      prettyPrint displayTz goodMeetings
+      T.putStrLn $ "All times are in " <> displayTzText <> "."

--- a/src/Meetings.hs
+++ b/src/Meetings.hs
@@ -142,10 +142,10 @@ absolutiseMeetings startTime' intervalMinutes tz rmwr =
     indexToTime idx = addUTCTime (intSecondsToNDT $ (unMinutes intervalMinutes) * 60 * idx) startTime'
 
 getMeetings :: [Schedule Person] -> [Schedule Room] -> Int -> Int -> UTCTime -> Minutes -> TimeZone -> [Meeting]
-getMeetings personSchedules roomSchedules inPerson nChunks startTime' intervalMinutes localTz =
+getMeetings personSchedules roomSchedules inPerson nChunks startTime' intervalMinutes londonTz =
   let relativeMeetings = findRelativeMeetings personSchedules nChunks
       relativeMeetingsWithRooms = map (addRoomsToMeeting roomSchedules) relativeMeetings
-      meetings = map (absolutiseMeetings startTime' intervalMinutes localTz) relativeMeetingsWithRooms
+      meetings = map (absolutiseMeetings startTime' intervalMinutes londonTz) relativeMeetingsWithRooms
    in filter (isMeetingGood inPerson) meetings
 
 getRoomMeetings :: [Schedule Room] -> Int -> Int -> UTCTime -> Minutes -> TimeZone -> [Meeting]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,15 +1,31 @@
 module Utils where
 
-import Entities (Minutes (..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock (getCurrentTime)
-import Data.Time.LocalTime (LocalTime (..), getCurrentTimeZone, utcToLocalTime)
+import Data.Time.LocalTime (LocalTime (..), TimeZone (..), getCurrentTimeZone, utcToLocalTime)
+import Data.Time.Zones (loadTZFromDB, timeZoneForUTCTime, utcToLocalTimeTZ)
+import Entities (Minutes (..))
 import Print (prettyThrow, prettyWarn)
 
 tshow :: (Show a) => a -> Text
 tshow = T.pack . show
 
+-- | Returns the current timezone in London (either GMT or BST).
+getCurrentLondonTZ :: IO TimeZone
+getCurrentLondonTZ = do
+  now <- getCurrentTime
+  london <- loadTZFromDB "Europe/London"
+  pure $ timeZoneForUTCTime london now
+
+-- | Returns the current time in London.
+getCurrentLondonTime :: IO LocalTime
+getCurrentLondonTime = do
+  now <- getCurrentTime
+  london <- loadTZFromDB "Europe/London"
+  pure $ utcToLocalTimeTZ london now
+
+-- | Returns the current local time, according to the user's system timezone.
 getCurrentLocalTime :: IO LocalTime
 getCurrentLocalTime = do
   now <- getCurrentTime


### PR DESCRIPTION
There are two separate issues with timezones, one is what the app uses internally to find meeting times, the other is what it shows you when you use it.

On the former:

- meetings are only searched for during London hours 0830-1730 (previously they would search in your local timezone, which was bad)

On the latter:

- by default meeting times are shown in London timezone
- adds a `--local` switch to allow programme to output meeting times in local timezone
- to avoid any ambiguity, the programme now tells you what timezone it's outputting times in