### PR TITLE
Cache OAuth token in ~/.cache/meet/token.json

### DIFF
--- a/meet.cabal
+++ b/meet.cabal
@@ -41,6 +41,7 @@ library
         process >= 1.6.18 && < 1.7,
         tz >= 0.1.3 && < 0.2,
         directory >= 1.3.8 && < 1.4,
+        filepath >= 1.4.200 && < 1.5,
 
 executable meet
     main-is:            Main.hs

--- a/meet.cabal
+++ b/meet.cabal
@@ -40,6 +40,7 @@ library
         req >= 3.13.2 && < 3.14,
         process >= 1.6.18 && < 1.7,
         tz >= 0.1.3 && < 0.2,
+        directory >= 1.3.8 && < 1.4,
 
 executable meet
     main-is:            Main.hs

--- a/meet.cabal
+++ b/meet.cabal
@@ -42,6 +42,7 @@ library
         tz >= 0.1.3 && < 0.2,
         directory >= 1.3.8 && < 1.4,
         filepath >= 1.4.200 && < 1.5,
+        unix >= 2.8.4 && < 2.9,
 
 executable meet
     main-is:            Main.hs

--- a/src/Azure.hs
+++ b/src/Azure.hs
@@ -30,6 +30,7 @@ import System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileEx
 import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory)
 import System.Process (readProcessWithExitCode, spawnCommand)
+import System.Posix.Files (setFileMode)
 
 data Token = Token
   { accessToken :: Text,
@@ -56,6 +57,7 @@ serialiseToken token = do
   fp <- getTokenJsonFilePath
   createDirectoryIfMissing True (takeDirectory fp)
   encodeFile fp token
+  setFileMode fp 0o600
 
 deserialiseToken :: IO (Maybe Token)
 deserialiseToken = do

--- a/src/Azure.hs
+++ b/src/Azure.hs
@@ -28,6 +28,7 @@ import Network.HTTP.Req
 import Print (prettyThrow)
 import System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileExist, getXdgDirectory)
 import System.Exit (ExitCode (..))
+import System.FilePath (takeDirectory)
 import System.Process (readProcessWithExitCode, spawnCommand)
 
 data Token = Token
@@ -53,8 +54,7 @@ getTokenJsonFilePath = getXdgDirectory XdgCache "meet/token.json"
 serialiseToken :: Token -> IO ()
 serialiseToken token = do
   fp <- getTokenJsonFilePath
-  cacheDir <- getXdgDirectory XdgCache "meet"
-  createDirectoryIfMissing True cacheDir
+  createDirectoryIfMissing True (takeDirectory fp)
   encodeFile fp token
 
 deserialiseToken :: IO (Maybe Token)


### PR DESCRIPTION
When the app runs, it checks whether there's a token there and if it's still valid (i.e. hasn't expired). If it's still valid it reuses it.

The token is stored with a refresh token, which in principle allows you to reobtain a new token even after it's expired. This bit hasn't been implemented yet.